### PR TITLE
Category filter refactor and other minor changes

### DIFF
--- a/src/app/properties/[id]/page.tsx
+++ b/src/app/properties/[id]/page.tsx
@@ -363,14 +363,18 @@ const PropertyDetailsView = ({ property }: PropertyDetailsViewProps) => {
               <MapViewer lat={property.latitude} lng={property.longitude} />
             </div>
 
-            {/* Estimate History */}
-            
-            <div>
-              <h4 className="mb-3 sm:mb-4 text-Arambo-Black h4">
-                Property Value History
-              </h4>
-              <EstimateHistory property={property} />
-            </div>
+            {property.propertyValueHistory && property.propertyValueHistory.length > 0 && (
+              <>
+                {/* Estimate History */}
+                
+                <div>
+                  <h4 className="mb-3 sm:mb-4 text-Arambo-Black h4">
+                    Property Value History
+                  </h4>
+                  <EstimateHistory property={property} />
+                </div>
+              </>
+            )}
            
           </div>
 

--- a/src/components/PropertyFIlter.tsx
+++ b/src/components/PropertyFIlter.tsx
@@ -172,25 +172,24 @@ export function PropertyFilter({ CategoryOptions, onFiltersChange, categoryType 
     }
   };
 
-  // Handle category toggle with URL params
+  // Handle category toggle with URL params (single selection only)
   const handleCategoryToggle = (category: string) => {
     const isSelected = localForm.categories.includes(category);
-    const newCategories = isSelected
-      ? localForm.categories.filter((c: string) => c !== category)
-      : [...localForm.categories, category];
+    // For single selection: if clicking the same category, deselect it; otherwise select the new one
+    const newCategories = isSelected ? [] : [category];
     
     setLocalForm((prev) => ({
       ...prev,
       categories: newCategories,
     }));
     
-    // Update URL with new category values (generic for both tenantType and furnishingStatus)
+    // Update URL with new category values (single value or empty array)
     updateCategoryValues(newCategories);
     
     // Create a complete filter object for the callback
     const categoryFilters: Partial<PropertyFilters> = {};
     
-    // Set the appropriate filter based on categoryType
+    // Set the appropriate filter based on categoryType (single value or undefined)
     if (categoryType === 'tenantType') {
       categoryFilters.tenantType = newCategories.length === 1 ? newCategories[0] as PropertyFilters['tenantType'] : undefined;
     } else if (categoryType === 'furnishingStatus') {

--- a/src/hooks/useUrlParams.ts
+++ b/src/hooks/useUrlParams.ts
@@ -92,16 +92,16 @@ export function useUrlParams(categoryType: 'tenantType' | 'furnishingStatus' = '
     const listingType = searchParams.get('listingType');
     if (listingType) params.listingType = listingType;
     
-    // Handle multiple tenantType values
-    const tenantTypes = searchParams.getAll('tenantType');
-    if (tenantTypes.length === 1) {
-      params.tenantType = tenantTypes[0] as PropertyFilters['tenantType'];
+    // Handle single tenantType value
+    const tenantType = searchParams.get('tenantType');
+    if (tenantType) {
+      params.tenantType = tenantType as PropertyFilters['tenantType'];
     }
     
-    // Handle multiple furnishingStatus values
-    const furnishingStatuses = searchParams.getAll('furnishingStatus');
-    if (furnishingStatuses.length === 1) {
-      params.furnishingStatus = furnishingStatuses[0] as PropertyFilters['furnishingStatus'];
+    // Handle single furnishingStatus value
+    const furnishingStatus = searchParams.get('furnishingStatus');
+    if (furnishingStatus) {
+      params.furnishingStatus = furnishingStatus as PropertyFilters['furnishingStatus'];
     }
     
     return params;
@@ -180,9 +180,10 @@ export function useUrlParams(categoryType: 'tenantType' | 'furnishingStatus' = '
     router.replace(`${pathname}${query}`);
   }, [pathname, router, searchParams]);
 
-  // Handle category values based on categoryType (tenantType or furnishingStatus)
+  // Handle category values based on categoryType (tenantType or furnishingStatus) - single selection only
   const categoryValues = useMemo(() => {
-    return searchParams.getAll(categoryType);
+    const singleValue = searchParams.get(categoryType);
+    return singleValue ? [singleValue] : [];
   }, [searchParams, categoryType]);
 
   const updateCategoryValues = useCallback((values: string[]) => {
@@ -191,10 +192,11 @@ export function useUrlParams(categoryType: 'tenantType' | 'furnishingStatus' = '
     // Remove all existing category params
     current.delete(categoryType);
     
-    // Add new category params
-    values.forEach(value => {
-      current.append(categoryType, value);
-    });
+    // Add single category param if values array has exactly one item
+    if (values.length === 1) {
+      current.set(categoryType, values[0]);
+    }
+    // If values array is empty, the param remains deleted (no category selected)
     
     const search = current.toString();
     const query = search ? `?${search}` : '';


### PR DESCRIPTION
## Pull Request: Feature/Refactor - Single Selection Filters & Property History Visibility

This PR introduces an important refactor to ensure **single selection** for the `tenantType` and `furnishingStatus` property filters, and adds a safeguard to only display the **Property Value History** section if relevant data is present.

### 🚀 Key Changes

1.  **Enforce Single Selection for Category Filters** (`src/components/PropertyFIlter.tsx` & `src/hooks/useUrlParams.ts`):
    * **`PropertyFilter.tsx`:** Updated `handleCategoryToggle` logic to ensure that only one category can be selected at a time. Clicking an unselected category selects it; clicking an already selected category deselects it. The internal state (`localForm.categories`) and the URL update now only ever contain **zero or one** value for the respective category type.
    * **`useUrlParams.ts`:**
        * The logic for reading filter values from the URL (`getFiltersFromUrl`) has been updated to use `searchParams.get()` instead of `searchParams.getAll()` for `tenantType` and `furnishingStatus`, correctly treating them as single, optional values.
        * The logic for updating category values (`updateCategoryValues`) now uses `current.set()` (or just deletes the param if no value is present) to ensure only a single parameter exists in the URL, as opposed to appending multiple.

2.  **Conditional Rendering for Property Value History** (`src/app/properties/[id]/page.tsx`):
    * The **Property Value History** section (which includes the `EstimateHistory` component) is now wrapped in a conditional check:
        ```tsx
        {property.propertyValueHistory && property.propertyValueHistory.length > 0 && ( ... )}
        ```
    * This ensures the heading and the component itself are only rendered if the `propertyValueHistory` array exists and contains data, preventing the display of an empty section.

### 💡 Rationale

* **Single Selection:** `tenantType` and `furnishingStatus` are inherently single-choice filters (a property cannot be 'Fully Furnished' *and* 'Unfurnished' simultaneously). This change corrects the filter behavior and standardizes URL parameter handling (`?furnishingStatus=fully_furnished` instead of `?furnishingStatus=fully_furnished&furnishingStatus=unfurnished`).
* **Cleaner UI:** Hiding the "Property Value History" section when there is no data improves the user experience by removing unnecessary, empty content on the property details page.

### 🧪 Testing

* Verify on the property list page that selecting a category filter (e.g., 'Tenant Type: Student') deselects any previous category in the same group.
* Check the URL after filtering; only one `tenantType` or `furnishingStatus` param should ever be present.
* View a property details page:
    * If the property has value history data, ensure the "Property Value History" section renders correctly.
    * If the property **lacks** value history data (mock data or real data without it), ensure the entire section and its heading are **not** displayed.